### PR TITLE
fix: pins clickhouse-connect and installs package from requirements.txt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Installation
 Requires a running Clickhouse database to connect to, you will be prompted for the
 password. Just clone the repo, install the requirements, and go. Defaults given are
 for a default install of the Tutor Clickhouse plugin:
-https://github.com/bmtcril/tutor-contrib-clickhouse
+https://github.com/openedx/tutor-contrib-clickhouse
 
 To get the password from a Tutor Clickhouse plugin, just run the following:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+black
+-r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-black
 click
-clickhouse-connect
+clickhouse-connect>0.5,<0.6
 psycopg2-binary
 pymongo[srv]
 requests

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,10 @@
 from setuptools import setup, find_packages
+from pkg_resources import parse_requirements
+
+requirements = [
+    str(req)
+    for req in parse_requirements(open('requirements.txt'))
+]
 
 setup(
     name="xapi-db-load",
@@ -9,17 +15,11 @@ setup(
         [console_scripts]
         xapi-db-load=xapi_db_load.main:load_db
     """,
-    install_requires=[
-        "click",
-        "clickhouse-connect",
-        "psycopg2-binary",
-        "pymongo[srv]",
-        "requests",
-    ],
-    url="https://github.com/bmtcril/xapi-db-load",
+    install_requires=requirements,
+    url="https://github.com/openedx/xapi-db-load",
     project_urls={
-        "Code": "https://github.com/bmtcril/xapi-db-load",
-        "Issue tracker": "https://github.com/bmtcril/xapi-db-load/issues",
+        "Code": "https://github.com/openedx/xapi-db-load",
+        "Issue tracker": "https://github.com/openedx/xapi-db-load/issues",
     },
     license="AGPLv3",
     author="Brian Mesick",


### PR DESCRIPTION
This PR pins `clickhouse-connect` to the version we know works with this code, and updates the setup.py to install the package requirements from `requirements.txt`.

I've also added a `requirements-dev.txt` to separate the dev dependencies.

**Related discussions**

* Part of implementing https://github.com/openedx/openedx-oars/issues/30

**Testing instructions**

1. Create a new virtualenv.
2. Check out this branch, and run `pip install .` to install this repo from `setup.py`.
3. Run `pip freeze` to check that the expected dependencies were installed at the expected versions.