### PR TITLE
refactor: parse block location for course metadata (FC-0024)

### DIFF
--- a/xapi_db_load/generate_load.py
+++ b/xapi_db_load/generate_load.py
@@ -236,7 +236,7 @@ class RandomCourse:
         return {
             "org": self.org,
             "course_key": self.course_id,
-            "location": block_id,
+            "location": block_id.split("/xblock/")[-1],
             "display_name": f"{block_type} {cnt}",
             # This is a catchall field, we don't currently use it
             "xblock_data_json": "{}",


### PR DESCRIPTION
I noticed a mismatch between the `course_blocks.location` field generated by this application and the data generated by importing the demo course. I believe this PR would make the data consistent between the two systems.