### PR TITLE
chore: updated security contact email

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,7 +161,7 @@ file in this repo.
 Reporting Security Issues
 *************************
 
-Please do not report security issues in public. Please email security@tcril.org.
+Please do not report security issues in public. Please email security@openedx.org.
 
 .. |pypi-badge| image:: https://img.shields.io/pypi/v/xapi-db-load.svg
     :target: https://pypi.python.org/pypi/xapi-db-load/


### PR DESCRIPTION
This PR relies on this [issue](https://github.com/openedx/wg-security/issues/15) to update the security email contact.