### PR TITLE
feat: insert course block record (FC-0024)

### DIFF
--- a/xapi_db_load/generate_load.py
+++ b/xapi_db_load/generate_load.py
@@ -244,6 +244,18 @@ class RandomCourse:
             "edited_on": self.end_date
         }
 
+    def _serialize_course_block(self):
+        return {
+            "org": self.org,
+            "course_key": self.course_id,
+            "location": f"block-v1:{self.course_id}+type@course+block@course",
+            "display_name": f"Course {self.course_uuid[:5]}",
+            # This is a catchall field, we don't currently use it
+            "xblock_data_json": "{}",
+            "order": 1,
+            "edited_on": self.end_date
+        }
+
     def serialize_block_data_for_event_sink(self):
         """
         Return a list of dicts representing all blocks in this course.
@@ -261,6 +273,7 @@ class RandomCourse:
         for s in self.known_sequential_ids:
             blocks.append(self._serialize_block("Sequential", s, cnt))
             cnt += 1
+        blocks.append(self._serialize_course_block())
 
         return blocks
 

--- a/xapi_db_load/generate_load.py
+++ b/xapi_db_load/generate_load.py
@@ -245,10 +245,11 @@ class RandomCourse:
         }
 
     def _serialize_course_block(self):
+        location_course_id = self.course_id.replace("course-v1:", "")
         return {
             "org": self.org,
             "course_key": self.course_id,
-            "location": f"block-v1:{self.course_id}+type@course+block@course",
+            "location": f"block-v1:{location_course_id}+type@course+block@course",
             "display_name": f"Course {self.course_uuid[:5]}",
             # This is a catchall field, we don't currently use it
             "xblock_data_json": "{}",


### PR DESCRIPTION
This PR adds a `course_block` record for the course itself. The resulting `location` field for the course block looks like this: `block-v1:tacoX+DemoX+a35b5259-8c03-4fe3-9a7b-5ddcd829b137+type@course+block@course`

This was based on the `location` field for the demo course block, which seemed to follow the pattern of `block-v1:{org}+{course}+{run}+type@course+block@course`. Since this format differs from the format expected by the existing `_serialize_block` method, I opted to add a new method to generate the course block specifically.