### PR TITLE
feat: Baby step in improving timing logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ build/
 *.egg-info/
 tests/__init__.py
 docs/_build/
+.tox/
+coverage.xml
+dist/

--- a/xapi_db_load/__init__.py
+++ b/xapi_db_load/__init__.py
@@ -2,4 +2,4 @@
 Scripts to generate fake xAPI data against various backends.
 """
 
-__version__ = "0.6"
+__version__ = "0.7"

--- a/xapi_db_load/backends/clickhouse_lake.py
+++ b/xapi_db_load/backends/clickhouse_lake.py
@@ -134,7 +134,7 @@ class XAPILakeClickhouse:
         self.client.command(sql)
 
         sql = f"""
-        CREATE OR REPLACE FUNCTION {self.get_org_function_name} AS (course_url) ->
+        CREATE FUNCTION IF NOT EXISTS {self.get_org_function_name} AS (course_url) ->
         nullIf(EXTRACT(course_url, 'course-v1:([a-zA-Z0-9]*)'), '')
         ;"""
 

--- a/xapi_db_load/backends/ralph_lrs.py
+++ b/xapi_db_load/backends/ralph_lrs.py
@@ -53,7 +53,6 @@ class XAPILRSRalphClickhouse(XAPILakeClickhouse):
         Ralph wants one json object per line, not an array of objects.
         """
         out_data = [json.loads(x["event"]) for x in events]
-        out_data = [json.loads(x["event"]) for x in events]
         resp = requests.post(  # pylint: disable=missing-timeout
             self.lrs_url,
             auth=(self.lrs_username, self.lrs_password),

--- a/xapi_db_load/main.py
+++ b/xapi_db_load/main.py
@@ -74,6 +74,11 @@ from xapi_db_load.utils import LogTimer, setup_timing
     help="Directory where the output files should be written when using the csv backend.",
     type=click.Path(exists=True, dir_okay=True, file_okay=False, writable=True)
 )
+@click.option(
+    "--log_dir",
+    help="The directory to log timing information to.",
+    type=click.Path(exists=True, dir_okay=True, file_okay=False, writable=True)
+)
 def load_db(
     backend,
     num_batches,
@@ -91,6 +96,7 @@ def load_db(
     lrs_username,
     lrs_password,
     csv_output_directory,
+    log_dir,
 ):
     """
     Execute the database load.
@@ -134,7 +140,7 @@ def load_db(
 
     # Sets up the timing logger. Here to prevent creating log files when
     # running --help or other commands.
-    setup_timing()
+    setup_timing(log_dir)
 
     if distributions_only:
         with LogTimer("distributions", "do_distributiuon"):

--- a/xapi_db_load/utils.py
+++ b/xapi_db_load/utils.py
@@ -1,0 +1,68 @@
+"""
+Utility code for xapi-db-load.
+"""
+import json
+import logging
+import os
+from datetime import datetime
+
+timing = logging.getLogger("timing")
+
+
+def setup_timing():
+    """
+    Set up the timing logger.
+
+    This should probably take an optional logging config file eventually.
+    """
+    formatter = logging.Formatter('%(message)s')
+    timing_log_name = f"logs/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}_timing.log"
+
+    parent_dir = "logs"
+
+    # If the logs dir is writable, use it. On systems like k8s where it's not,
+    # output to the screen.
+    if not os.access(parent_dir, os.W_OK):
+        handler = logging.FileHandler(timing_log_name)
+        print(f"Logging timing data to {timing_log_name}")
+    else:
+        handler = logging.StreamHandler()
+        print(f"{parent_dir} is not writable, logging timing data to stdout.")
+
+    handler.setFormatter(formatter)
+    timing.addHandler(handler)
+    timing.setLevel(logging.INFO)
+
+
+class LogTimer:
+    """
+    Class to time and log our various operations.
+    """
+
+    start_time = None
+
+    def __init__(self, timer_type, timer_key):
+        self.timer_type = timer_type
+        self.timer_key = timer_key
+
+    def __enter__(self):
+        self.start_time = datetime.now()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        log_duration(
+            self.timer_type,
+            self.timer_key,
+            (datetime.now() - self.start_time).total_seconds()
+        )
+
+
+def log_duration(timer_type, timer_key, duration):
+    """
+    Log timing data to the configured logger.
+
+    timer_type: Top level type of the timer ("query", "batch_load", "setup"...)
+    timer_key: Specific timer ("Count of Users", "Batch 100", "init"...)
+    duration: Timing in fractional seconds (1.20, 12.345, 0.03)
+    """
+    stmt = {'time': datetime.now().isoformat(), 'timer': timer_type, 'key': timer_key, 'duration': duration}
+    timing.info(json.dumps(stmt))

--- a/xapi_db_load/utils.py
+++ b/xapi_db_load/utils.py
@@ -9,25 +9,21 @@ from datetime import datetime
 timing = logging.getLogger("timing")
 
 
-def setup_timing():
+def setup_timing(log_dir):
     """
     Set up the timing logger.
 
     This should probably take an optional logging config file eventually.
     """
     formatter = logging.Formatter('%(message)s')
-    timing_log_name = f"logs/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}_timing.log"
 
-    parent_dir = "logs"
-
-    # If the logs dir is writable, use it. On systems like k8s where it's not,
-    # output to the screen.
-    if not os.access(parent_dir, os.W_OK):
-        handler = logging.FileHandler(timing_log_name)
+    if log_dir:
+        timing_log_name = os.path.join(log_dir, f"{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}_timing.log")
         print(f"Logging timing data to {timing_log_name}")
+        handler = logging.FileHandler(timing_log_name)
     else:
+        print("No log dir provided, logging timing data to stdout.")
         handler = logging.StreamHandler()
-        print(f"{parent_dir} is not writable, logging timing data to stdout.")
 
     handler.setFormatter(formatter)
     timing.addHandler(handler)


### PR DESCRIPTION
Adds a "timing" logger that stores timestamped log files in the "logs" dir if it's writable, otherwise prints to screen. This is to support upcoming load tests, but can be made more configurable if others end up using it.

Closes: #8 