### PR TITLE
feat: add grade_calculated events (FC-0033) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ docs/_build/
 .tox/
 coverage.xml
 dist/
+.venv
+.dir-locals.el

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
 """
 Setup for xapi-db-load.
 """
-import os
-import re
-
 from setuptools import find_packages, setup
 
 from xapi_db_load import __version__

--- a/xapi_db_load/generate_load.py
+++ b/xapi_db_load/generate_load.py
@@ -7,7 +7,7 @@ import uuid
 from random import choice, choices, randrange
 
 from .course_configs import CourseConfigLarge, CourseConfigMedium, CourseConfigSmall, CourseConfigWhopper
-from .xapi.xapi_grade import FirstTimePassed
+from .xapi.xapi_grade import CourseGradeCalculated, FirstTimePassed
 from .xapi.xapi_hint_answer import ShowAnswer, ShowHint
 from .xapi.xapi_navigation import LinkClicked, NextNavigation, PreviousNavigation, TabSelectedNavigation
 from .xapi.xapi_problem import BrowserProblemCheck, ServerProblemCheck
@@ -34,8 +34,8 @@ EVENT_LOAD = (
     (PlayedVideo, 24.519),
     (PausedVideo, 14.912),
     (StoppedVideo, 3.671),
-    (PositionChangedVideo, 13.105),
-    (BrowserProblemCheck, 8.726),
+    (PositionChangedVideo, 12.105),
+    (BrowserProblemCheck, 8.226),
     (ServerProblemCheck, 8.593),
     (NextNavigation, 6.05),
     (PreviousNavigation, 0.811),
@@ -46,6 +46,7 @@ EVENT_LOAD = (
     (ShowAnswer, 1.373),
     (TranscriptEnabled, 0.05),
     (TranscriptDisabled, 0.05),
+    (CourseGradeCalculated, 1.5),
 )
 
 EVENTS = [i[0] for i in EVENT_LOAD]

--- a/xapi_db_load/xapi/xapi_grade.py
+++ b/xapi_db_load/xapi/xapi_grade.py
@@ -2,6 +2,7 @@
 Fake xAPI statements for various grading events.
 """
 import json
+import random
 from uuid import uuid4
 
 from .xapi_common import XAPIBase
@@ -66,3 +67,130 @@ class FirstTimePassed(XAPIBase):
         }
 
         return json.dumps(event)
+
+
+class GradeCalculated(XAPIBase):
+    """
+    Base xAPI event for grade_calculated events.
+    """
+
+    verb = "http://id.tincanapi.com/verb/earned"
+    verb_display = "earned"
+    object_type = None
+
+    def get_data(self):
+        """
+        Generate and return the event dict, including xAPI statement as "event".
+        """
+        event_id = str(uuid4())
+        actor_id = self.parent_load_generator.get_actor()
+        course = self.parent_load_generator.get_course()
+        emission_time = course.get_random_emission_time()
+
+        e = self.get_randomized_event(event_id, actor_id, course, emission_time)
+        return {
+            "event_id": event_id,
+            "verb": self.verb,
+            "actor_id": actor_id,
+            "org": course.org,
+            "course_run_id": course.course_url,
+            "emission_time": emission_time,
+            "event": e,
+        }
+
+    def get_randomized_event(self, event_id, actor_id, course, emission_time):
+        """
+        Given the inputs, return an xAPI statement for a grade_calculated event.
+        """
+        max_score = random.randint(1, 100)
+        raw_score = random.randint(0, max_score)
+        scaled_score = raw_score / max_score
+        score_obj = {
+            "scaled": scaled_score,
+            "raw": raw_score,
+            "min": 0.0,
+            "max": max_score
+        }
+
+        event = {
+            "actor": {
+                "account": {
+                    "homePage": "http://localhost:18000",
+                    "name": actor_id
+                },
+                "objectType": "Agent"
+            },
+            "id": event_id,
+            "verb": {
+                "id": self.verb,
+                "display": {
+                    "en": self.verb_display
+                }
+            },
+            "context": {
+                "contextActivities": {
+                    "parent": [
+                        {
+                            "id": course.course_url,
+                            "objectType": "Activity",
+                            "definition": {
+                                "name": {
+                                    "en-US": "Demonstration Course"
+                                },
+                                "type": "http://adlnet.gov/expapi/activities/course"
+                            },
+                        }
+                    ]
+                },
+                "extensions": {
+                    "https://w3id.org/xapi/openedx/extension/transformer-version": "event-routing-backends@5.6.0"
+                },
+            },
+            "version": "1.0.3",
+            "timestamp": emission_time.isoformat(),
+        }
+
+        if self.object_type == "course":
+            grade_classification = "Pass" if scaled_score > 0.65 else "Fail"
+            course_fields = {
+                "object": {
+                    "id": course.course_url,
+                    "definition": {
+                        "name": {"en": "Demonstration Course"},
+                        "type": "http://adlnet.gov/expapi/activities/course",
+                    },
+                    "objectType": "Activity",
+                },
+                "result": {
+                    "score": score_obj,
+                    "extensions": {
+                        "http://www.tincanapi.co.uk/activitytypes/grade_classification": grade_classification
+                    }
+                }
+            }
+            event.update(course_fields)
+        elif self.object_type == "subsection":
+            subsection_fields = {
+                "object": {
+                    "id": course.get_random_sequential_id(),
+                    "definition": {
+                        "type": "http://id.tincanapi.com/activitytype/resource"
+                    },
+                    "objectType": "Activity"
+                },
+                "result": {
+                    "score": score_obj,
+                    "success": random.choice([True, False]),
+                }
+            }
+            event.update(subsection_fields)
+
+        return json.dumps(event)
+
+
+class CourseGradeCalculated(GradeCalculated):
+    object_type = "course"
+
+
+class SubsectionGradeCalculated(GradeCalculated):
+    object_type = "subsection"


### PR DESCRIPTION
This adds two new events: course and subsection grade_calculated events. Although, since we're only using the course-level events right now, only those are created.

These events have a random score attached to them and result in a varied distribution of grades when viewed in the instructor dashboard.