### PR TITLE
chore: Fix make upgrade

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,7 @@
 -c constraints.txt
 
 click
-clickhouse-connect>0.5<0.7
+clickhouse-connect>=0.5,<0.7
 pyyaml
 requests
 smart_open[s3]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-boto3==1.34.131
+boto3==1.34.144
     # via smart-open
-botocore==1.34.131
+botocore==1.34.144
     # via
     #   boto3
     #   s3transfer
-certifi==2024.6.2
+certifi==2024.7.4
     # via
     #   clickhouse-connect
     #   requests
@@ -18,7 +18,7 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via -r requirements/base.in
-clickhouse-connect==0.7.12
+clickhouse-connect==0.6.23
     # via -r requirements/base.in
 idna==3.7
     # via requests
@@ -36,7 +36,7 @@ pyyaml==6.0.1
     # via -r requirements/base.in
 requests==2.32.3
     # via -r requirements/base.in
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via boto3
 six==1.16.0
     # via python-dateutil
@@ -49,5 +49,5 @@ urllib3==1.26.19
     #   requests
 wrapt==1.16.0
     # via smart-open
-zstandard==0.22.0
+zstandard==0.23.0
     # via clickhouse-connect

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -32,7 +32,7 @@ tomli==2.0.1
     # via
     #   pyproject-api
     #   tox
-tox==4.15.1
+tox==4.16.0
     # via -r requirements/ci.in
 virtualenv==20.26.3
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==3.2.2
+astroid==3.2.3
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -13,11 +13,11 @@ backports-tarfile==1.2.0
     # via
     #   -r requirements/quality.txt
     #   jaraco-context
-boto3==1.34.131
+boto3==1.34.144
     # via
     #   -r requirements/quality.txt
     #   smart-open
-botocore==1.34.131
+botocore==1.34.144
     # via
     #   -r requirements/quality.txt
     #   boto3
@@ -30,15 +30,11 @@ cachetools==5.3.3
     # via
     #   -r requirements/ci.txt
     #   tox
-certifi==2024.6.2
+certifi==2024.7.4
     # via
     #   -r requirements/quality.txt
     #   clickhouse-connect
     #   requests
-cffi==1.16.0
-    # via
-    #   -r requirements/quality.txt
-    #   cryptography
 chardet==5.2.0
     # via
     #   -r requirements/ci.txt
@@ -60,7 +56,7 @@ click-log==0.4.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-clickhouse-connect==0.7.12
+clickhouse-connect==0.6.23
     # via -r requirements/quality.txt
 code-annotations==1.8.0
     # via
@@ -70,15 +66,11 @@ colorama==0.4.6
     # via
     #   -r requirements/ci.txt
     #   tox
-coverage[toml]==7.5.4
+coverage[toml]==7.6.0
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
-cryptography==42.0.8
-    # via
-    #   -r requirements/quality.txt
-    #   secretstorage
-diff-cover==9.0.0
+diff-cover==9.1.0
     # via -r requirements/dev.in
 dill==0.3.8
     # via
@@ -94,7 +86,7 @@ docutils==0.20.1
     #   readme-renderer
 edx-lint==5.3.6
     # via -r requirements/quality.txt
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via
     #   -r requirements/quality.txt
     #   pytest
@@ -139,11 +131,6 @@ jaraco-functools==4.0.1
     # via
     #   -r requirements/quality.txt
     #   keyring
-jeepney==0.8.0
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.4
     # via
     #   -r requirements/quality.txt
@@ -183,7 +170,7 @@ more-itertools==10.3.0
     #   -r requirements/quality.txt
     #   jaraco-classes
     #   jaraco-functools
-nh3==0.2.17
+nh3==0.2.18
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
@@ -202,7 +189,7 @@ pbr==6.0.0
     #   stevedore
 pip-tools==7.4.1
     # via -r requirements/pip-tools.txt
-pkginfo==1.11.1
+pkginfo==1.10.0
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -222,10 +209,6 @@ pluggy==1.5.0
     #   tox
 pycodestyle==2.12.0
     # via -r requirements/quality.txt
-pycparser==2.22
-    # via
-    #   -r requirements/quality.txt
-    #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
 pygments==2.18.0
@@ -234,7 +217,7 @@ pygments==2.18.0
     #   diff-cover
     #   readme-renderer
     #   rich
-pylint==3.2.3
+pylint==3.2.5
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -306,14 +289,10 @@ rich==13.7.1
     # via
     #   -r requirements/quality.txt
     #   twine
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via
     #   -r requirements/quality.txt
     #   boto3
-secretstorage==3.3.3
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
 six==1.16.0
     # via
     #   -r requirements/quality.txt
@@ -345,13 +324,13 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.12.5
+tomlkit==0.13.0
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==4.15.1
+tox==4.16.0
     # via -r requirements/ci.txt
-twine==5.1.0
+twine==5.1.1
     # via -r requirements/quality.txt
 typing-extensions==4.12.2
     # via
@@ -384,7 +363,7 @@ zipp==3.19.2
     #   -r requirements/quality.txt
     #   importlib-metadata
     #   importlib-resources
-zstandard==0.22.0
+zstandard==0.23.0
     # via
     #   -r requirements/quality.txt
     #   clickhouse-connect

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -16,44 +16,40 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via pydata-sphinx-theme
-boto3==1.34.131
+boto3==1.34.144
     # via
     #   -r requirements/test.txt
     #   smart-open
-botocore==1.34.131
+botocore==1.34.144
     # via
     #   -r requirements/test.txt
     #   boto3
     #   s3transfer
 build==1.2.1
     # via -r requirements/doc.in
-certifi==2024.6.2
+certifi==2024.7.4
     # via
     #   -r requirements/test.txt
     #   clickhouse-connect
     #   requests
-cffi==1.16.0
-    # via cryptography
 charset-normalizer==3.3.2
     # via
     #   -r requirements/test.txt
     #   requests
 click==8.1.7
     # via -r requirements/test.txt
-clickhouse-connect==0.7.12
+clickhouse-connect==0.6.23
     # via -r requirements/test.txt
-coverage[toml]==7.5.4
+coverage[toml]==7.6.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==42.0.8
-    # via secretstorage
 docutils==0.19
     # via
     #   pydata-sphinx-theme
     #   readme-renderer
     #   sphinx
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -82,10 +78,6 @@ jaraco-context==5.3.0
     # via keyring
 jaraco-functools==4.0.1
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.4
     # via sphinx
 jmespath==1.0.1
@@ -109,7 +101,7 @@ more-itertools==10.3.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-nh3==0.2.17
+nh3==0.2.18
     # via readme-renderer
 packaging==24.1
     # via
@@ -118,14 +110,12 @@ packaging==24.1
     #   pydata-sphinx-theme
     #   pytest
     #   sphinx
-pkginfo==1.11.1
+pkginfo==1.10.0
     # via twine
 pluggy==1.5.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pycparser==2.22
-    # via cffi
 pydata-sphinx-theme==0.14.4
     # via sphinx-book-theme
 pygments==2.18.0
@@ -168,12 +158,10 @@ rfc3986==2.0.0
     # via twine
 rich==13.7.1
     # via twine
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via
     #   -r requirements/test.txt
     #   boto3
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via
     #   -r requirements/test.txt
@@ -209,7 +197,7 @@ tomli==2.0.1
     #   build
     #   coverage
     #   pytest
-twine==5.1.0
+twine==5.1.1
     # via -r requirements/doc.in
 typing-extensions==4.12.2
     # via
@@ -230,7 +218,7 @@ zipp==3.19.2
     # via
     #   importlib-metadata
     #   importlib-resources
-zstandard==0.22.0
+zstandard==0.23.0
     # via
     #   -r requirements/test.txt
     #   clickhouse-connect

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.43.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.1
+pip==24.1.2
     # via -r requirements/pip.in
-setuptools==70.1.0
+setuptools==70.3.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,28 +4,26 @@
 #
 #    make upgrade
 #
-astroid==3.2.2
+astroid==3.2.3
     # via
     #   pylint
     #   pylint-celery
 backports-tarfile==1.2.0
     # via jaraco-context
-boto3==1.34.131
+boto3==1.34.144
     # via
     #   -r requirements/test.txt
     #   smart-open
-botocore==1.34.131
+botocore==1.34.144
     # via
     #   -r requirements/test.txt
     #   boto3
     #   s3transfer
-certifi==2024.6.2
+certifi==2024.7.4
     # via
     #   -r requirements/test.txt
     #   clickhouse-connect
     #   requests
-cffi==1.16.0
-    # via cryptography
 charset-normalizer==3.3.2
     # via
     #   -r requirements/test.txt
@@ -38,23 +36,21 @@ click==8.1.7
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-clickhouse-connect==0.7.12
+clickhouse-connect==0.6.23
     # via -r requirements/test.txt
 code-annotations==1.8.0
     # via edx-lint
-coverage[toml]==7.5.4
+coverage[toml]==7.6.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==42.0.8
-    # via secretstorage
 dill==0.3.8
     # via pylint
 docutils==0.20.1
     # via readme-renderer
 edx-lint==5.3.6
     # via -r requirements/quality.in
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -83,10 +79,6 @@ jaraco-context==5.3.0
     # via keyring
 jaraco-functools==4.0.1
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.4
     # via code-annotations
 jmespath==1.0.1
@@ -112,7 +104,7 @@ more-itertools==10.3.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-nh3==0.2.17
+nh3==0.2.18
     # via readme-renderer
 packaging==24.1
     # via
@@ -120,7 +112,7 @@ packaging==24.1
     #   pytest
 pbr==6.0.0
     # via stevedore
-pkginfo==1.11.1
+pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
     # via pylint
@@ -130,15 +122,13 @@ pluggy==1.5.0
     #   pytest
 pycodestyle==2.12.0
     # via -r requirements/quality.in
-pycparser==2.22
-    # via cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
 pygments==2.18.0
     # via
     #   readme-renderer
     #   rich
-pylint==3.2.3
+pylint==3.2.5
     # via
     #   edx-lint
     #   pylint-celery
@@ -185,12 +175,10 @@ rfc3986==2.0.0
     # via twine
 rich==13.7.1
     # via twine
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via
     #   -r requirements/test.txt
     #   boto3
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via
     #   -r requirements/test.txt
@@ -210,9 +198,9 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.12.5
+tomlkit==0.13.0
     # via pylint
-twine==5.1.0
+twine==5.1.1
     # via -r requirements/quality.in
 typing-extensions==4.12.2
     # via
@@ -234,7 +222,7 @@ zipp==3.19.2
     # via
     #   importlib-metadata
     #   importlib-resources
-zstandard==0.22.0
+zstandard==0.23.0
     # via
     #   -r requirements/test.txt
     #   clickhouse-connect

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,16 +4,16 @@
 #
 #    make upgrade
 #
-boto3==1.34.131
+boto3==1.34.144
     # via
     #   -r requirements/base.txt
     #   smart-open
-botocore==1.34.131
+botocore==1.34.144
     # via
     #   -r requirements/base.txt
     #   boto3
     #   s3transfer
-certifi==2024.6.2
+certifi==2024.7.4
     # via
     #   -r requirements/base.txt
     #   clickhouse-connect
@@ -24,11 +24,11 @@ charset-normalizer==3.3.2
     #   requests
 click==8.1.7
     # via -r requirements/base.txt
-clickhouse-connect==0.7.12
+clickhouse-connect==0.6.23
     # via -r requirements/base.txt
-coverage[toml]==7.5.4
+coverage[toml]==7.6.0
     # via pytest-cov
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via pytest
 idna==3.7
     # via
@@ -65,7 +65,7 @@ pyyaml==6.0.1
     # via -r requirements/base.txt
 requests==2.32.3
     # via -r requirements/base.txt
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -89,7 +89,7 @@ wrapt==1.16.0
     # via
     #   -r requirements/base.txt
     #   smart-open
-zstandard==0.22.0
+zstandard==0.23.0
     # via
     #   -r requirements/base.txt
     #   clickhouse-connect


### PR DESCRIPTION
Upgrades have been failing due to the way version pins are being checked. This fixes is and catches us up on new versions.