### PR TITLE
chore: Update Python version for tests to 3.11 & 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         os: [ ubuntu-20.04 ]
         python-version: [ '3.11','3.12' ]
-        toxenv: [ quality, docs, pytest ]
     permissions:
       # Gives the action the necessary permissions for publishing new
       # comments in pull requests.
@@ -38,25 +37,4 @@ jobs:
         run: pip install -r requirements/ci.txt
 
       - name: Run Tests
-        env:
-          TOXENV: ${{ matrix.toxenv }}
         run: tox
-
-      - name: Run coverage
-        if: matrix.python-version == '3.11' && matrix.toxenv == 'django42'
-        uses: py-cov-action/python-coverage-comment-action@v3
-        with:
-          GITHUB_TOKEN: ${{ github.token }}
-          MINIMUM_GREEN: 90
-          MINIMUM_ORANGE: 85
-          ANNOTATE_MISSING_LINES: true
-          ANNOTATION_TYPE: error
-
-      - name: Store Pull Request comment to be posted
-        uses: actions/upload-artifact@v4
-        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
-        with:
-          # If you use a different name, update COMMENT_ARTIFACT_NAME accordingly
-          name: python-coverage-comment-action
-          # If you use a different name, update COMMENT_FILENAME accordingly
-          path: python-coverage-comment-action.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,19 +7,56 @@ on:
     branches: [ main ]
 
 jobs:
-  tests:
-    runs-on: ubuntu-latest
+  run_tests:
+    name: tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04 ]
+        python-version: [ '3.11','3.12' ]
+        toxenv: [ quality, docs, pytest ]
+    permissions:
+      # Gives the action the necessary permissions for publishing new
+      # comments in pull requests.
+      pull-requests: write
+      # Gives the action the necessary permissions for pushing data to the
+      # python-coverage-comment-action branch, and for editing existing
+      # comments (to avoid publishing multiple comments in the same PR)
+      contents: write
+
     steps:
-
-      - uses: actions/checkout@v3
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - name: setup python
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
 
-      - name: Install development dependencies
-        run: make requirements
+      - name: Install pip
+        run: pip install -r requirements/pip.txt
 
-      - name: Tests
+      - name: Install Dependencies
+        run: pip install -r requirements/ci.txt
+
+      - name: Run Tests
+        env:
+          TOXENV: ${{ matrix.toxenv }}
         run: tox
+
+      - name: Run coverage
+        if: matrix.python-version == '3.11' && matrix.toxenv == 'django42'
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 85
+          ANNOTATE_MISSING_LINES: true
+          ANNOTATION_TYPE: error
+
+      - name: Store Pull Request comment to be posted
+        uses: actions/upload-artifact@v4
+        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+        with:
+          # If you use a different name, update COMMENT_ARTIFACT_NAME accordingly
+          name: python-coverage-comment-action
+          # If you use a different name, update COMMENT_FILENAME accordingly
+          path: python-coverage-comment-action.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38}
+envlist = py{311,312}
 
 [doc8]
 ; D001 = Line too long
@@ -36,14 +36,14 @@ ignore = D101,D105,D107,D200,D203,D212,D215,D404,D405,D406,D407,D408,D409,D410,D
 
 
 [pytest]
-addopts = --cov xapi_db_load --cov-report term-missing --cov-report xml
+addopts = --cov xapi_db_load --cov-report term-missing --cov-report xml --log-level=INFO
 norecursedirs = .* docs requirements site-packages
 
 [testenv]
 deps =
     -r{toxinidir}/requirements/test.txt
 commands =
-    pytest --cov xapi_db_load --cov-report term-missing --cov-report xml
+    pytest {posargs} --full-trace
 
 [testenv:docs]
 setenv =


### PR DESCRIPTION
Changing from testing just 3.8. New requirements are needing 3.9+, and the rest of the platform is on 3.11 soon moving to 3.12. See the failure here: https://github.com/openedx/xapi-db-load/pull/112#event-13593916918