### PR TITLE
feat: Add course runs to the generated courses

### DIFF
--- a/xapi_db_load/course_configs.py
+++ b/xapi_db_load/course_configs.py
@@ -73,6 +73,8 @@ class RandomCourse:
     def __init__(
         self,
         org,
+        course_uuid,
+        course_run,
         overall_start_date,
         overall_end_date,
         course_length,
@@ -80,10 +82,14 @@ class RandomCourse:
         course_config_name,
         course_size_makeup
     ):
-        self.course_uuid = str(uuid.uuid4())[:6]
+        self.course_uuid = course_uuid
+        self.course_run = course_run
+        # It's important that the course name stay the same between runs
+        # as Superset limitations have us filtering by course name and we want
+        # to be able to catch all course runs in those queries.
         self.course_name = f"{self.course_uuid} ({course_config_name})"
         self.org = org
-        self.course_id = f"course-v1:{org}+DemoX+{self.course_uuid}"
+        self.course_id = f"course-v1:{org}+{self.course_uuid}+{self.course_run}"
         self.course_url = f"http://localhost:18000/course/{self.course_id}"
 
         delta = datetime.timedelta(days=course_length)

--- a/xapi_db_load/generate_load.py
+++ b/xapi_db_load/generate_load.py
@@ -3,6 +3,7 @@ Generates batches of random xAPI events.
 """
 import datetime
 import pprint
+import random
 import uuid
 from random import choice, choices
 
@@ -106,20 +107,39 @@ class EventGenerator:
         """
         for course_config_name, num_courses in self.config["num_course_sizes"].items():
             print(f"Setting up {num_courses} {course_config_name} courses")
-            for _ in range(num_courses):
+
+            curr_num = 0
+            while curr_num < num_courses:
                 course_config_makeup = self.config["course_size_makeup"][course_config_name]
                 org = choice(self.orgs)
                 actors = choices(self.actors, k=course_config_makeup["actors"])
+                runs = random.randrange(1, 5)
+                course_id = str(uuid.uuid4())[:6]
 
-                self.courses.append(RandomCourse(
-                    org,
-                    self.start_date,
-                    self.end_date,
-                    self.config["course_length_days"],
-                    actors,
-                    course_config_name,
-                    course_config_makeup
-                ))
+                # Create 1-5 of the same course size / makeup / name
+                # but different course runs.
+                for run_id in range(runs):
+                    course = RandomCourse(
+                        org,
+                        course_id,
+                        run_id,
+                        self.start_date,
+                        self.end_date,
+                        self.config["course_length_days"],
+                        actors,
+                        course_config_name,
+                        course_config_makeup
+                    )
+
+                    self.courses.append(course)
+
+                    curr_num += 1
+
+                    # Don't let our number of runs overrun the total number
+                    # of this type of course
+                    if curr_num == num_courses:
+                        break
+
 
     def setup_actors(self):
         """


### PR DESCRIPTION
Does not increase the number of courses created, just make each course have 1-5 runs associated with it.

Closes: #128 