### PR TITLE
fix: Load from S3 button runs create instead

### DIFF
--- a/xapi_db_load/runner.py
+++ b/xapi_db_load/runner.py
@@ -66,10 +66,12 @@ class Runner:
         # or just loading existing data. Either way, we block this thread here until all tasks are
         # complete.
         if load_db_only:
+            self.logger.debug("Runner: Running tasks for load_db_only")
             results = await asyncio.gather(
                 *[task.run_db_load_task() for task in self.test_data_tasks]
             )
         else:
+            self.logger.debug("Runner: Running tasks")
             results = await asyncio.gather(
                 *[task.run_task() for task in self.test_data_tasks]
             )

--- a/xapi_db_load/ui/load_ui.py
+++ b/xapi_db_load/ui/load_ui.py
@@ -35,7 +35,7 @@ class LoadData(urwid.WidgetWrap):
             """.format(**s)
         )
         self.go_button = urwid.Button(GO_TEXT, self.go_pressed)
-        self.load_button = urwid.Button(LOAD_TEXT, self.go_pressed)
+        self.load_button = urwid.Button(LOAD_TEXT, self.load_pressed)
         self.all_widgets = [
             urwid.Padding(self.title, width="clip", align="center"),
             self.summary,


### PR DESCRIPTION
- A couple of fixes to UI mode. Clicking the button to load from S3 performed the "create" action instead.
- Counters were not updating for loading xapi from S3
- No message indicated that there were no files to load from the S3 location