### PR TITLE
chore: Requirements upgrade

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,7 +3,7 @@
 
 chdb                   # Embedded ClickHouse client
 click                  # Command line interface library
-clickhouse-connect     # ClickHouse client
+clickhouse-connect[async] # ClickHouse client
 pyyaml                 # YAML parser
 pyarrow                # Required by chdb for internal data conversion
 requests               # HTTP library

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,9 +4,17 @@
 #
 #    make upgrade
 #
-boto3==1.43.6
+aiohappyeyeballs==2.6.1
+    # via aiohttp
+aiohttp==3.13.5
+    # via clickhouse-connect
+aiosignal==1.4.0
+    # via aiohttp
+attrs==26.1.0
+    # via aiohttp
+boto3==1.43.9
     # via smart-open
-botocore==1.43.6
+botocore==1.43.9
     # via
     #   boto3
     #   s3transfer
@@ -16,28 +24,42 @@ certifi==2026.4.22
     #   requests
 charset-normalizer==3.4.7
     # via requests
-chdb==4.1.6
+chdb==4.1.7
     # via -r requirements/base.in
-chdb-core==26.1.0
+chdb-core==26.3.0
     # via chdb
-click==8.3.3
+click==8.4.0
     # via -r requirements/base.in
-clickhouse-connect==0.15.1
+clickhouse-connect[async]==1.0.0
     # via -r requirements/base.in
-idna==3.14
-    # via requests
+frozenlist==1.8.0
+    # via
+    #   aiohttp
+    #   aiosignal
+idna==3.15
+    # via
+    #   requests
+    #   yarl
 jmespath==1.1.0
     # via
     #   boto3
     #   botocore
 lz4==4.4.5
     # via clickhouse-connect
-numpy==2.4.4
+multidict==6.7.1
+    # via
+    #   aiohttp
+    #   yarl
+numpy==2.4.5
     # via pandas
-pandas==3.0.2
+pandas==3.0.3
     # via
     #   chdb
     #   chdb-core
+propcache==0.5.2
+    # via
+    #   aiohttp
+    #   yarl
 pyarrow==24.0.0
     # via
     #   -r requirements/base.in
@@ -47,11 +69,9 @@ python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   pandas
-pytz==2026.2
-    # via clickhouse-connect
 pyyaml==6.0.3
     # via -r requirements/base.in
-requests==2.33.1
+requests==2.34.2
     # via -r requirements/base.in
 s3transfer==0.17.0
     # via boto3
@@ -59,6 +79,8 @@ six==1.17.0
     # via python-dateutil
 smart-open[s3]==7.6.1
     # via -r requirements/base.in
+typing-extensions==4.15.0
+    # via aiosignal
 urllib3==2.7.0
     # via
     #   botocore
@@ -72,5 +94,7 @@ wcwidth==0.7.0
     # via urwid
 wrapt==2.1.2
     # via smart-open
+yarl==1.23.0
+    # via aiohttp
 zstandard==0.25.0
     # via clickhouse-connect

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-cachetools==7.1.1
+cachetools==7.1.2
     # via tox
 colorama==0.4.6
     # via tox
@@ -28,13 +28,13 @@ pluggy==1.6.0
     # via tox
 pyproject-api==1.10.0
     # via tox
-python-discovery==1.3.0
+python-discovery==1.3.1
     # via
     #   tox
     #   virtualenv
 tomli-w==1.2.0
     # via tox
-tox==4.53.1
+tox==4.54.0
     # via -r requirements/ci.in
-virtualenv==21.3.1
+virtualenv==21.3.3
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,16 +4,32 @@
 #
 #    make upgrade
 #
+aiohappyeyeballs==2.6.1
+    # via
+    #   -r requirements/quality.txt
+    #   aiohttp
+aiohttp==3.13.5
+    # via
+    #   -r requirements/quality.txt
+    #   clickhouse-connect
+aiosignal==1.4.0
+    # via
+    #   -r requirements/quality.txt
+    #   aiohttp
 astroid==4.0.4
     # via
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-boto3==1.43.6
+attrs==26.1.0
+    # via
+    #   -r requirements/quality.txt
+    #   aiohttp
+boto3==1.43.9
     # via
     #   -r requirements/quality.txt
     #   smart-open
-botocore==1.43.6
+botocore==1.43.9
     # via
     #   -r requirements/quality.txt
     #   boto3
@@ -22,7 +38,7 @@ build==1.5.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==7.1.1
+cachetools==7.1.2
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -41,13 +57,13 @@ charset-normalizer==3.4.7
     # via
     #   -r requirements/quality.txt
     #   requests
-chdb==4.1.6
+chdb==4.1.7
     # via -r requirements/quality.txt
-chdb-core==26.1.0
+chdb-core==26.3.0
     # via
     #   -r requirements/quality.txt
     #   chdb
-click==8.3.3
+click==8.4.0
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
@@ -59,7 +75,7 @@ click-log==0.4.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-clickhouse-connect==0.15.1
+clickhouse-connect[async]==1.0.0
     # via -r requirements/quality.txt
 code-annotations==3.0.0
     # via
@@ -99,14 +115,20 @@ filelock==3.29.0
     #   python-discovery
     #   tox
     #   virtualenv
+frozenlist==1.8.0
+    # via
+    #   -r requirements/quality.txt
+    #   aiohttp
+    #   aiosignal
 id==1.6.1
     # via
     #   -r requirements/quality.txt
     #   twine
-idna==3.14
+idna==3.15
     # via
     #   -r requirements/quality.txt
     #   requests
+    #   yarl
 iniconfig==2.3.0
     # via
     #   -r requirements/quality.txt
@@ -123,7 +145,7 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/quality.txt
     #   keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.5.0
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -171,11 +193,16 @@ more-itertools==11.0.2
     #   -r requirements/quality.txt
     #   jaraco-classes
     #   jaraco-functools
+multidict==6.7.1
+    # via
+    #   -r requirements/quality.txt
+    #   aiohttp
+    #   yarl
 nh3==0.3.5
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
-numpy==2.4.4
+numpy==2.4.5
     # via
     #   -r requirements/quality.txt
     #   pandas
@@ -190,7 +217,7 @@ packaging==26.2
     #   tox
     #   twine
     #   wheel
-pandas==3.0.2
+pandas==3.0.3
     # via
     #   -r requirements/quality.txt
     #   chdb
@@ -213,6 +240,11 @@ pluggy==1.6.0
     #   pytest
     #   pytest-cov
     #   tox
+propcache==0.5.2
+    # via
+    #   -r requirements/quality.txt
+    #   aiohttp
+    #   yarl
 pyarrow==24.0.0
     # via
     #   -r requirements/quality.txt
@@ -276,7 +308,7 @@ python-dateutil==2.9.0.post0
     #   -r requirements/quality.txt
     #   botocore
     #   pandas
-python-discovery==1.3.0
+python-discovery==1.3.1
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -285,10 +317,6 @@ python-slugify==8.0.4
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-pytz==2026.2
-    # via
-    #   -r requirements/quality.txt
-    #   clickhouse-connect
 pyyaml==6.0.3
     # via
     #   -r requirements/quality.txt
@@ -297,7 +325,7 @@ readme-renderer==44.0
     # via
     #   -r requirements/quality.txt
     #   twine
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/quality.txt
     #   requests-toolbelt
@@ -333,7 +361,7 @@ snowballstemmer==3.0.1
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
-stevedore==5.7.0
+stevedore==5.8.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -350,13 +378,14 @@ tomlkit==0.15.0
     #   -r requirements/quality.txt
     #   edx-lint
     #   pylint
-tox==4.53.1
+tox==4.54.0
     # via -r requirements/ci.txt
 twine==6.2.0
     # via -r requirements/quality.txt
 typing-extensions==4.15.0
     # via
     #   -r requirements/quality.txt
+    #   aiosignal
     #   pytest-asyncio
 urllib3==2.7.0
     # via
@@ -370,7 +399,7 @@ urwid==4.0.0
     # via -r requirements/quality.txt
 uvloop==0.22.1
     # via -r requirements/quality.txt
-virtualenv==21.3.1
+virtualenv==21.3.3
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -386,6 +415,10 @@ wrapt==2.1.2
     # via
     #   -r requirements/quality.txt
     #   smart-open
+yarl==1.23.0
+    # via
+    #   -r requirements/quality.txt
+    #   aiohttp
 zstandard==0.25.0
     # via
     #   -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,19 +6,35 @@
 #
 accessible-pygments==0.0.5
     # via pydata-sphinx-theme
+aiohappyeyeballs==2.6.1
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
+aiohttp==3.13.5
+    # via
+    #   -r requirements/test.txt
+    #   clickhouse-connect
+aiosignal==1.4.0
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
 alabaster==1.0.0
     # via sphinx
+attrs==26.1.0
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
 babel==2.18.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
 beautifulsoup4==4.14.3
     # via pydata-sphinx-theme
-boto3==1.43.6
+boto3==1.43.9
     # via
     #   -r requirements/test.txt
     #   smart-open
-botocore==1.43.6
+botocore==1.43.9
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -36,15 +52,15 @@ charset-normalizer==3.4.7
     # via
     #   -r requirements/test.txt
     #   requests
-chdb==4.1.6
+chdb==4.1.7
     # via -r requirements/test.txt
-chdb-core==26.1.0
+chdb-core==26.3.0
     # via
     #   -r requirements/test.txt
     #   chdb
-click==8.3.3
+click==8.4.0
     # via -r requirements/test.txt
-clickhouse-connect==0.15.1
+clickhouse-connect[async]==1.0.0
     # via -r requirements/test.txt
 coverage[toml]==7.14.0
     # via
@@ -57,12 +73,18 @@ docutils==0.22.4
     #   pydata-sphinx-theme
     #   readme-renderer
     #   sphinx
+frozenlist==1.8.0
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
+    #   aiosignal
 id==1.6.1
     # via twine
-idna==3.14
+idna==3.15
     # via
     #   -r requirements/test.txt
     #   requests
+    #   yarl
 imagesize==2.0.0
     # via sphinx
 iniconfig==2.3.0
@@ -73,7 +95,7 @@ jaraco-classes==3.4.0
     # via keyring
 jaraco-context==6.1.2
     # via keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.5.0
     # via keyring
 jeepney==0.9.0
     # via
@@ -102,9 +124,14 @@ more-itertools==11.0.2
     # via
     #   jaraco-classes
     #   jaraco-functools
+multidict==6.7.1
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
+    #   yarl
 nh3==0.3.5
     # via readme-renderer
-numpy==2.4.4
+numpy==2.4.5
     # via
     #   -r requirements/test.txt
     #   pandas
@@ -115,7 +142,7 @@ packaging==26.2
     #   pytest
     #   sphinx
     #   twine
-pandas==3.0.2
+pandas==3.0.3
     # via
     #   -r requirements/test.txt
     #   chdb
@@ -125,6 +152,11 @@ pluggy==1.6.0
     #   -r requirements/test.txt
     #   pytest
     #   pytest-cov
+propcache==0.5.2
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
+    #   yarl
 pyarrow==24.0.0
     # via
     #   -r requirements/test.txt
@@ -159,15 +191,11 @@ python-dateutil==2.9.0.post0
     #   -r requirements/test.txt
     #   botocore
     #   pandas
-pytz==2026.2
-    # via
-    #   -r requirements/test.txt
-    #   clickhouse-connect
 pyyaml==6.0.3
     # via -r requirements/test.txt
 readme-renderer==44.0
     # via twine
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/test.txt
     #   requests-toolbelt
@@ -221,6 +249,7 @@ twine==6.2.0
 typing-extensions==4.15.0
     # via
     #   -r requirements/test.txt
+    #   aiosignal
     #   beautifulsoup4
     #   pydata-sphinx-theme
     #   pytest-asyncio
@@ -244,6 +273,10 @@ wrapt==2.1.2
     # via
     #   -r requirements/test.txt
     #   smart-open
+yarl==1.23.0
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
 zstandard==0.25.0
     # via
     #   -r requirements/test.txt

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,7 +6,7 @@
 #
 build==1.5.0
     # via pip-tools
-click==8.3.3
+click==8.4.0
     # via pip-tools
 packaging==26.2
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,15 +4,31 @@
 #
 #    make upgrade
 #
+aiohappyeyeballs==2.6.1
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
+aiohttp==3.13.5
+    # via
+    #   -r requirements/test.txt
+    #   clickhouse-connect
+aiosignal==1.4.0
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
 astroid==4.0.4
     # via
     #   pylint
     #   pylint-celery
-boto3==1.43.6
+attrs==26.1.0
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
+boto3==1.43.9
     # via
     #   -r requirements/test.txt
     #   smart-open
-botocore==1.43.6
+botocore==1.43.9
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -28,13 +44,13 @@ charset-normalizer==3.4.7
     # via
     #   -r requirements/test.txt
     #   requests
-chdb==4.1.6
+chdb==4.1.7
     # via -r requirements/test.txt
-chdb-core==26.1.0
+chdb-core==26.3.0
     # via
     #   -r requirements/test.txt
     #   chdb
-click==8.3.3
+click==8.4.0
     # via
     #   -r requirements/test.txt
     #   click-log
@@ -42,7 +58,7 @@ click==8.3.3
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-clickhouse-connect==0.15.1
+clickhouse-connect[async]==1.0.0
     # via -r requirements/test.txt
 code-annotations==3.0.0
     # via edx-lint
@@ -58,12 +74,18 @@ docutils==0.22.4
     # via readme-renderer
 edx-lint==6.1.0
     # via -r requirements/quality.in
+frozenlist==1.8.0
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
+    #   aiosignal
 id==1.6.1
     # via twine
-idna==3.14
+idna==3.15
     # via
     #   -r requirements/test.txt
     #   requests
+    #   yarl
 iniconfig==2.3.0
     # via
     #   -r requirements/test.txt
@@ -76,7 +98,7 @@ jaraco-classes==3.4.0
     # via keyring
 jaraco-context==6.1.2
     # via keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.5.0
     # via keyring
 jeepney==0.9.0
     # via
@@ -107,9 +129,14 @@ more-itertools==11.0.2
     # via
     #   jaraco-classes
     #   jaraco-functools
+multidict==6.7.1
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
+    #   yarl
 nh3==0.3.5
     # via readme-renderer
-numpy==2.4.4
+numpy==2.4.5
     # via
     #   -r requirements/test.txt
     #   pandas
@@ -118,7 +145,7 @@ packaging==26.2
     #   -r requirements/test.txt
     #   pytest
     #   twine
-pandas==3.0.2
+pandas==3.0.3
     # via
     #   -r requirements/test.txt
     #   chdb
@@ -130,6 +157,11 @@ pluggy==1.6.0
     #   -r requirements/test.txt
     #   pytest
     #   pytest-cov
+propcache==0.5.2
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
+    #   yarl
 pyarrow==24.0.0
     # via
     #   -r requirements/test.txt
@@ -177,17 +209,13 @@ python-dateutil==2.9.0.post0
     #   pandas
 python-slugify==8.0.4
     # via code-annotations
-pytz==2026.2
-    # via
-    #   -r requirements/test.txt
-    #   clickhouse-connect
 pyyaml==6.0.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
 readme-renderer==44.0
     # via twine
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/test.txt
     #   requests-toolbelt
@@ -213,7 +241,7 @@ smart-open[s3]==7.6.1
     # via -r requirements/test.txt
 snowballstemmer==3.0.1
     # via pydocstyle
-stevedore==5.7.0
+stevedore==5.8.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
@@ -226,6 +254,7 @@ twine==6.2.0
 typing-extensions==4.15.0
     # via
     #   -r requirements/test.txt
+    #   aiosignal
     #   pytest-asyncio
 urllib3==2.7.0
     # via
@@ -247,6 +276,10 @@ wrapt==2.1.2
     # via
     #   -r requirements/test.txt
     #   smart-open
+yarl==1.23.0
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
 zstandard==0.25.0
     # via
     #   -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,11 +4,27 @@
 #
 #    make upgrade
 #
-boto3==1.43.6
+aiohappyeyeballs==2.6.1
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+aiohttp==3.13.5
+    # via
+    #   -r requirements/base.txt
+    #   clickhouse-connect
+aiosignal==1.4.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+boto3==1.43.9
     # via
     #   -r requirements/base.txt
     #   smart-open
-botocore==1.43.6
+botocore==1.43.9
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -22,22 +38,28 @@ charset-normalizer==3.4.7
     # via
     #   -r requirements/base.txt
     #   requests
-chdb==4.1.6
+chdb==4.1.7
     # via -r requirements/base.txt
-chdb-core==26.1.0
+chdb-core==26.3.0
     # via
     #   -r requirements/base.txt
     #   chdb
-click==8.3.3
+click==8.4.0
     # via -r requirements/base.txt
-clickhouse-connect==0.15.1
+clickhouse-connect[async]==1.0.0
     # via -r requirements/base.txt
 coverage[toml]==7.14.0
     # via pytest-cov
-idna==3.14
+frozenlist==1.8.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+    #   aiosignal
+idna==3.15
     # via
     #   -r requirements/base.txt
     #   requests
+    #   yarl
 iniconfig==2.3.0
     # via pytest
 jmespath==1.1.0
@@ -49,13 +71,18 @@ lz4==4.4.5
     # via
     #   -r requirements/base.txt
     #   clickhouse-connect
-numpy==2.4.4
+multidict==6.7.1
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+    #   yarl
+numpy==2.4.5
     # via
     #   -r requirements/base.txt
     #   pandas
 packaging==26.2
     # via pytest
-pandas==3.0.2
+pandas==3.0.3
     # via
     #   -r requirements/base.txt
     #   chdb
@@ -64,6 +91,11 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
+propcache==0.5.2
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+    #   yarl
 pyarrow==24.0.0
     # via
     #   -r requirements/base.txt
@@ -84,13 +116,9 @@ python-dateutil==2.9.0.post0
     #   -r requirements/base.txt
     #   botocore
     #   pandas
-pytz==2026.2
-    # via
-    #   -r requirements/base.txt
-    #   clickhouse-connect
 pyyaml==6.0.3
     # via -r requirements/base.txt
-requests==2.33.1
+requests==2.34.2
     # via -r requirements/base.txt
 s3transfer==0.17.0
     # via
@@ -103,7 +131,10 @@ six==1.17.0
 smart-open[s3]==7.6.1
     # via -r requirements/base.txt
 typing-extensions==4.15.0
-    # via pytest-asyncio
+    # via
+    #   -r requirements/base.txt
+    #   aiosignal
+    #   pytest-asyncio
 urllib3==2.7.0
     # via
     #   -r requirements/base.txt
@@ -122,6 +153,10 @@ wrapt==2.1.2
     # via
     #   -r requirements/base.txt
     #   smart-open
+yarl==1.23.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 zstandard==0.25.0
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
Needed to add a new async extra to support async https in clickhouse connect 1.0.

See: https://github.com/ClickHouse/clickhouse-connect/blob/eb24221add8308abf1fab928182fde80ad2ceaee/MIGRATION.md?plain=1#L114